### PR TITLE
Replace deprecated `path` with `curve`

### DIFF
--- a/src/apply.typ
+++ b/src/apply.typ
@@ -5,7 +5,7 @@
   #set circle(stroke: theme-data.subtle, fill: theme-data.overlay)
   #set ellipse(stroke: theme-data.subtle, fill: theme-data.overlay)
   #set line(stroke: theme-data.subtle)
-  #set path(stroke: theme-data.subtle, fill: theme-data.overlay)
+  #set curve(stroke: theme-data.subtle, fill: theme-data.overlay)
   #set polygon(stroke: theme-data.subtle, fill: theme-data.overlay)
   #set rect(stroke: theme-data.subtle, fill: theme-data.overlay)
   #set square(stroke: theme-data.subtle, fill: theme-data.overlay)

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rose-pine"
-version = "0.2.0"
+version = "0.2.1"
 entrypoint = "lib.typ"
 authors = ["oplik0", "Rosé Pine"]
 license = "MIT"


### PR DESCRIPTION
Typst 13.1 was giving me a deprecation warning, and this PR should clear it. I suppose I should also bump the package version, should it be to `0.2.1`?